### PR TITLE
Remove rogue `app.listen`

### DIFF
--- a/index.md
+++ b/index.md
@@ -48,8 +48,6 @@ app.get('/', function(req, res){
    res.send("Hello dxw!");
 });
 
-app.listen(3000);
-
 module.exports = { app };
 ```
 


### PR DESCRIPTION
This confused me when spinning up the app, I got:

```
Error: listen EADDRINUSE: address already in use :::3000
```

And running the tests gave me:

```
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

It was only after running the tests with `--detectOpenHandles` that I discovered there were two calls to `app.listen` - one in the app and one in the server.

That'll teach me to blindly copy and paste code!