### PR TITLE
Switch guidance to `nodenv`

### DIFF
--- a/level_01.md
+++ b/level_01.md
@@ -2,9 +2,9 @@
 ---
 # Level 01
 
-## NVM
+## Nodenv
 
-Install nvm (the Node Version Manager, like `rbenv`) via homebrew: `brew install nvm`.
+Install [`nodenv`](https://github.com/nodenv/nodenv/blob/master/README.md) (`rbenv` for Node) via homebrew: `brew install nodenv`. Note the caveats have you add to your `.{z,ba}shrc` - you'll need this for it to work.
 
 ## Node versions
 
@@ -12,15 +12,15 @@ Node has a pattern of regular major version releases purely based on a calendar 
 
 Even-numbered major versions are the more stable ones which will get long-term support, so in general it's best to stick to those.
 
-Install node: `nvm install 14`
+Install Node: `nodenv install 14.14.0`
 
-Set the node version for a project in `.nvmrc` and run `nvm use` to select it.
+Set the Node version for a project in `.node-version` and `nodenv` will use it automatically when you're in that directory or a sub-directory (like `rbenv`).
 
 ## NPM
 
 `npm` is the equivalent of `bundler`. `yarn` does the same job, and we could standardise on that - it has stronger locking of packages, which might be good.
 
-nvm can help us make sure it's all good to go: `nvm install-latest-npm`
+`nodenv` will have installed the matching version of `npm` for you, but if you want to update it, you can always run `npm install --global npm@latest` to update it.
 
 In a new directory you can then run `npm init` to create the `package.json`, which is the equivalent of the `Gemfile`.
 


### PR DESCRIPTION
We've standardized many repos to `nodenv` already, and it's more familiar to people using `rbenv` (which appears to be our standard).